### PR TITLE
correct dates, links & status section

### DIFF
--- a/errata/xquery-31/html/xpath-31-errata.html
+++ b/errata/xquery-31/html/xpath-31-errata.html
@@ -255,13 +255,13 @@ a.judgment:visited, a.judgment:link     { font-family: sans-serif;
 a.processing:visited, a.processing:link { color: black; 
                               		        text-decoration: none }
 a.env:visited, a.env:link               { color: black; 
-                                          text-decoration: none }</style><link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/2016/base.css"></head><body><div><h1>Draft Errata for XML Path Language (XPath) 3.1 </h1><h2><a name="w3c-doctype" id="w3c-doctype"></a>13 October 2017</h2><dl><dt>Latest version:</dt><dd><a href="http://www.w3.org/XML/2007/qt-errata/xpath-31-errata.html">http://www.w3.org/XML/2007/qt-errata/xpath-31-errata.html</a></dd><dt>Editor:</dt><dd>Michael Kay, Saxonica <a href="http://www.saxonica.com/">http://www.saxonica.com/</a></dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.eu/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr><div><h2><a name="abstract" id="abstract"></a>Abstract</h2><p>This document addresses errors in the
-         <a href="http://www.w3.org/TR/2017/REC-xpath-31-20170321/">XML Path Language (XPath) 3.1 </a>
-         Recommendation published on 14&nbsp;March&nbsp;2017. 
+                                          text-decoration: none }</style><link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/2016/base.css"></head><body><div><h1>Draft Errata for XML Path Language (XPath) 3.1 </h1><h2><a name="w3c-doctype" id="w3c-doctype"></a>13 October 2017</h2><dl><dt>Latest version:</dt><dd><a href="https://www.w3.org/XML/2017/qt-errata/xpath-31-errata.html">https://www.w3.org/XML/2017/qt-errata/xpath-31-errata.html</a></dd><dt>Editor:</dt><dd>Michael Kay, Saxonica <a href="http://www.saxonica.com/">http://www.saxonica.com/</a></dd></dl><p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="https://www.ercim.eu/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr><div><h2><a name="abstract" id="abstract"></a>Abstract</h2><p>This document addresses errors in the
+         <a href="https://www.w3.org/TR/2017/REC-xpath-31-20170321/">XML Path Language (XPath) 3.1 </a>
+         Recommendation published on 21 March&nbsp;2017.
          It records all errors that, at the time of this document's publication,
          have solutions that have been approved by the
-		 <a href="http://www.w3.org/XML/Query">XML Query Working Group</a>. 
-         For updates see the <a href="http://www.w3.org/TR/xpath-31/">latest version</a> of that document. </p><p>The errata are numbered,
+		 <a href="https://www.w3.org/XML/Query">XML Query Working Group</a> and the <a href="https://www.w3.org/XML/Query">XML Query Working Group</a>.
+         For updates see the <a href="https://www.w3.org/TR/xpath-31/">latest version</a> of that document. </p><p>The errata are numbered,
          and are listed in reverse chronological order of their date of origin.
 		 Each erratum is classified as
          Substantive, Editorial, or Markup. These categories are defined as follows:</p><ul><li><p><b>Substantive: </b> a change to the specification that may require
@@ -274,36 +274,14 @@ a.env:visited, a.env:link               { color: black;
 	however these visual clues are not essential to an understanding of the change.
 	The styling of old and new text is an approximation to its appearance in the
 	published Recommendation, but is not normative. Hyperlinks are shown underlined
-	in the erratum text, but the links are not live.</p><p>A number of indexes appear at the end of the document.</p><p>Substantive corrections are proposed by the
-	     <a href="http://www.w3.org/XML/Query">XML Query Working Group</a>
-         (part of the <a href="http://www.w3.org/XML/Activity">XML Activity</a>),
-         where there is consensus that they are appropriate;
-         they are not to be considered normative until approved by a
-         <a href="http://www.w3.org/2004/02/Process-20040205/tr.html#cfr-corrections">Call
-         for Review of Proposed Corrections</a> or a
-         <a href="http://www.w3.org/2004/02/Process-20040205/tr.html#cfr-edited">Call
-         for Review of an Edited Recommendation</a>. </p><p>Please report errors in this document using W3C's 
-		 <a href="http://www.w3.org/Bugs/Public/">public Bugzilla system</a> 
-		 (instructions can be found at 
-		 <a href="http://www.w3.org/XML/2005/04/qt-bugzilla">http://www.w3.org/XML/2005/04/qt-bugzilla</a>).
-		 If access to that system is not feasible, you may send your comments to the
-         W3C XSLT/XPath/XQuery public comments mailing list,
-         <a href="mailto:public-qt-comments@w3.org">public-qt-comments@w3.org</a>. 
-         It will be very helpful if you include the string
-         [XQ31errata]
-         in the subject line of your report, whether made in Bugzilla or in email.
-		 Each Bugzilla entry and email message should contain only one error report. 
-         Archives of the comments and responses are available at
-         <a href="http://lists.w3.org/Archives/Public/public-qt-comments/">
-         http://lists.w3.org/Archives/Public/public-qt-comments/</a>. 
-	</p></div><div><h2><a name="status" id="status"></a>Status of this Document</h2><p><em>This is an editor's draft. </em>
-		  None of the errata reported in this document have been approved
-		  by a <a href="http://www.w3.org/2004/02/Process-20040205/tr.html#cfr-corrections">Call for Review of Proposed Corrections</a> or a
-		  <a href="http://www.w3.org/2004/02/Process-20040205/tr.html#cfr-edited">Call for Review of an Edited Recommendation</a>. 
-		  As a consequence, they must not be considered to be normative.
-		  </p><p>The Working Group does not intend to progress these errata to normative status; instead, it
-		  intends to publish a second edition of the Recommendation incorporating these errata, and to progress
-		  the second edition to normative status.</p></div><div><h2><a name="contents" id="contents"></a>Table of Contents</h2><p>&nbsp;&nbsp;<b>Errata</b></p><p>&nbsp;&nbsp;&nbsp;&nbsp;
+	in the erratum text, but the links are not live.</p><p>A number of indexes appear at the end of the document.</p>
+    </div>
+
+    <div><h2><a name="status" id="status"></a>Status of this Document</h2><p><em>This is a public draft.</em>
+        It is maintained in accordance with the W3C process on <a href="https://www.w3.org/2017/Process-20170301/#errata">Errata Management</a>.
+        None of the errata reported in this document must be considered normative.
+    </p></div>
+    <div><h2><a name="contents" id="contents"></a>Table of Contents</h2><p>&nbsp;&nbsp;<b>Errata</b></p><p>&nbsp;&nbsp;&nbsp;&nbsp;
 	    <a href="#E4">XQ31.E4</a>&nbsp;&nbsp;
 		Some examples in the section concerned with the unary lookup operator are actually examples of postfix lookup.</p><p>&nbsp;&nbsp;&nbsp;&nbsp;
 	    <a href="#E3">XQ31.E3</a>&nbsp;&nbsp;
@@ -312,7 +290,7 @@ a.env:visited, a.env:link               { color: black;
 		The term "Query Environment" (used in the definition of external functions) is not explained; furthermore it is used in XPath as well as XQuery.</p><p>&nbsp;&nbsp;&nbsp;&nbsp;
 	    <a href="#E1">XQ31.E1</a>&nbsp;&nbsp;
 		The introductory section on Atomizations mentions that FOTY0012 can be raised, but other errors (for example, FOTY0013) are also possible.</p><p>&nbsp;&nbsp;<b>Indexes</b></p><p>&nbsp;&nbsp;&nbsp;&nbsp;<a href="#index-by-section">Index by affected section</a></p><p>&nbsp;&nbsp;&nbsp;&nbsp;<a href="#index-by-bugzilla">Index by Bugzilla entry</a></p><p>&nbsp;&nbsp;&nbsp;&nbsp;<a href="#index-by-error">Index by
-	        error</a></p></div><hr><h2><a id="E4" name="E4">XQ31.E4 - editorial</a></h2><p><i>See <a href="http://www.w3.org/Bugs/Public/show_bug.cgi?id=30175">Bug 30175</a></i></p><h3>Description</h3><p>Some examples in the section concerned with the unary lookup operator are actually
+	        error</a></p></div><hr><h2><a id="E4" name="E4">XQ31.E4 - editorial</a></h2><p><i>See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=30175">Bug 30175</a></i></p><h3>Description</h3><p>Some examples in the section concerned with the unary lookup operator are actually
 				examples of postfix lookup.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Changes</h3><ol><li><p>In 3.11.3.1 Unary Lookup (first bulleted list, seventh item):</p><p><i>Delete the text:</i></p><div style="border: medium double rgb(255,0,0)"><ul><li><p>If <code>$m</code> is bound to the weekdays map described in <span style="text-decoration: underline">3.11.1 Maps</span>, then <code>$m?*</code> returns the values <code>("Sunday","Monday","Tuesday","Wednesday", "Thursday", "Friday","Saturday")</code>, in <span style="text-decoration: underline">implementation-dependent</span> order.</p></li></ul></div></li><li><p>In 3.11.3.1 Unary Lookup (first bulleted list, eighth item):</p><p><i>Delete the text:</i></p><div style="border: medium double rgb(255,0,0)"><ul><li><p>
                            <code>[1, 2, 5, 7]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p></li></ul></div></li><li><p>In 3.11.3.1 Unary Lookup (first bulleted list, ninth item):</p><p><i>Delete the text:</i></p><div style="border: medium double rgb(255,0,0)"><ul><li><p>
                            <code>[[1, 2, 3], [4, 5, 6]]?*</code> evaluates to <code>([1, 2, 3], [4, 5, 6])</code>
@@ -331,7 +309,7 @@ a.env:visited, a.env:link               { color: black;
 						<code>[1, 2, 5, 7]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p></li></ul><ul><li><p>
 						<code>[[1, 2, 3], [4, 5, 6]]?*</code> evaluates to <code>([1, 2, 3], [4,
 							5, 6])</code>
-					</p></li></ul></div></li></ol><h2><a id="E3" name="E3">XQ31.E3 - editorial</a></h2><p><i>See <a href="http://www.w3.org/Bugs/Public/show_bug.cgi?id=30169">Bug 30169</a></i></p><h3>Description</h3><p>The definition of "pure union types" is unnecessarily complex.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Change</h3><p>In 2.5 Types (fifth paragraph):</p><p><i>Replace the text:</i></p><div style="border: medium double rgb(255,0,0)"><p>
+					</p></li></ul></div></li></ol><h2><a id="E3" name="E3">XQ31.E3 - editorial</a></h2><p><i>See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=30169">Bug 30169</a></i></p><h3>Description</h3><p>The definition of "pure union types" is unnecessarily complex.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Change</h3><p>In 2.5 Types (fifth paragraph):</p><p><i>Replace the text:</i></p><div style="border: medium double rgb(255,0,0)"><p>
                <span class="termdef"><a id="dt-pure-union-type"></a>[Definition]  A <b>pure union type</b> is an XML Schema union type that satisfies the following constraints:
 (1) <code>{variety}</code> is <code>union</code>, (2) the <code>{facets}</code> property is empty, (3) no type in the transitive membership of the union type has <code>{variety}</code> 
                   <code>list</code>, and (4) no type in the transitive membership of the union type is a type with <code>{variety}</code> 
@@ -341,7 +319,7 @@ a.env:visited, a.env:link               { color: black;
 						constraints: (1) <code>{variety}</code> is <code>union</code>, (2) 
 						<code>{facets}</code> is empty, (3) each type in its transitive
 						membership is a <span style="text-decoration: underline">generalized atomic type</span>.</span></p><div class="note"><p class="prefix"><b>Note:</b></p><p>The term <b>transitive membership</b> is defined in [XML Schema 1.1 Part 2]; the
-				definition is equally applicable to XSD 1.0.</p></div></div><h2><a id="E2" name="E2">XQ31.E2 - editorial</a></h2><p><i>See <a href="http://www.w3.org/Bugs/Public/show_bug.cgi?id=30155">Bug 30155</a></i></p><h3>Description</h3><p>The term "Query Environment" (used in the definition of external functions) is not explained; furthermore it
+				definition is equally applicable to XSD 1.0.</p></div></div><h2><a id="E2" name="E2">XQ31.E2 - editorial</a></h2><p><i>See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=30155">Bug 30155</a></i></p><h3>Description</h3><p>The term "Query Environment" (used in the definition of external functions) is not explained; furthermore it
 				is used in XPath as well as XQuery. This erratum fixes the problem by defining external functions without
 			reference to the concept.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Change</h3><p>In 2.1.2 Dynamic Context (first bulleted list, fifth item):</p><p><i>Replace the text:</i></p><div style="border: medium double rgb(255,0,0)"><p>
                         <span class="termdef"><a id="dt-named-functions"></a>[Definition]  
@@ -396,7 +374,7 @@ a.env:visited, a.env:link               { color: black;
 								function</b> is an <span style="text-decoration: underline">external function</span> that is
 							<span style="text-decoration: underline">implementation-defined</span>
 						</span>. 
-				</p></div><h2><a id="E1" name="E1">XQ31.E1 - editorial</a></h2><p><i>See <a href="http://www.w3.org/Bugs/Public/show_bug.cgi?id=30153">Bug 30153</a></i></p><h3>Description</h3><p>The introductory section on Atomizations mentions that FOTY0012 can be raised, but other errors (for example, FOTY0013) 
+				</p></div><h2><a id="E1" name="E1">XQ31.E1 - editorial</a></h2><p><i>See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=30153">Bug 30153</a></i></p><h3>Description</h3><p>The introductory section on Atomizations mentions that FOTY0012 can be raised, but other errors (for example, FOTY0013)
 		  	are also possible.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Change</h3><p>In 2.4.2 Atomization (first paragraph):</p><p><i>Replace the text:</i></p><div style="border: medium double rgb(255,0,0)"><p>The semantics of some
 XPath 3.1 operators depend on a process called <span style="text-decoration: underline">atomization</span>. Atomization is
 applied to a value when the value is used in a context in which a

--- a/errata/xquery-31/html/xquery-31-errata.html
+++ b/errata/xquery-31/html/xquery-31-errata.html
@@ -255,13 +255,13 @@ a.judgment:visited, a.judgment:link     { font-family: sans-serif;
 a.processing:visited, a.processing:link { color: black; 
                               		        text-decoration: none }
 a.env:visited, a.env:link               { color: black; 
-                                          text-decoration: none }</style><link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/2016/base.css"></head><body><div><h1>Draft Errata for XQuery 3.1: An XML Query Language </h1><h2><a name="w3c-doctype" id="w3c-doctype"></a>13 October 2017</h2><dl><dt>Latest version:</dt><dd><a href="http://www.w3.org/XML/2007/qt-errata/xquery-31-errata.html">http://www.w3.org/XML/2007/qt-errata/xquery-31-errata.html</a></dd><dt>Editor:</dt><dd>Michael Kay, Saxonica <a href="http://www.saxonica.com/">http://www.saxonica.com/</a></dd></dl><p class="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="http://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="http://www.ercim.eu/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="http://www.keio.ac.jp/">Keio</a>), All Rights Reserved. W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr><div><h2><a name="abstract" id="abstract"></a>Abstract</h2><p>This document addresses errors in the
-         <a href="http://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1: An XML Query Language </a>
-         Recommendation published on 14&nbsp;March&nbsp;2017. 
+                                          text-decoration: none }</style><link rel="stylesheet" type="text/css" href="https://www.w3.org/StyleSheets/TR/2016/base.css"></head><body><div><h1>Draft Errata for XQuery 3.1: An XML Query Language </h1><h2><a name="w3c-doctype" id="w3c-doctype"></a>13 October 2017</h2><dl><dt>Latest version:</dt><dd><a href="https://www.w3.org/XML/2017/qt-errata/xquery-31-errata.html">https://www.w3.org/XML/2017/qt-errata/xquery-31-errata.html</a></dd><dt>Editor:</dt><dd>Michael Kay, Saxonica <a href="http://www.saxonica.com/">http://www.saxonica.com/</a></dd></dl><p class="copyright"><a href="https://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2017 <a href="https://www.w3.org/"><acronym title="World Wide Web Consortium">W3C</acronym></a><sup>®</sup> (<a href="https://www.csail.mit.edu/"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a>, <a href="https://www.ercim.eu/"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a>, <a href="https://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>, <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and <a href="https://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p></div><hr><div><h2><a name="abstract" id="abstract"></a>Abstract</h2><p>This document addresses errors in the
+         <a href="https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1: An XML Query Language </a>
+         Recommendation published on 21 March&nbsp;2017.
          It records all errors that, at the time of this document's publication,
          have solutions that have been approved by the
-		 <a href="http://www.w3.org/XML/Query">XML Query Working Group</a>. 
-         For updates see the <a href="http://www.w3.org/TR/xquery-31/">latest version</a> of that document. </p><p>The errata are numbered,
+		 <a href="https://www.w3.org/XML/Query">XML Query Working Group</a>.
+         For updates see the <a href="https://www.w3.org/TR/xquery-31/">latest version</a> of that document. </p><p>The errata are numbered,
          and are listed in reverse chronological order of their date of origin.
 		 Each erratum is classified as
          Substantive, Editorial, or Markup. These categories are defined as follows:</p><ul><li><p><b>Substantive: </b> a change to the specification that may require
@@ -274,36 +274,14 @@ a.env:visited, a.env:link               { color: black;
 	however these visual clues are not essential to an understanding of the change.
 	The styling of old and new text is an approximation to its appearance in the
 	published Recommendation, but is not normative. Hyperlinks are shown underlined
-	in the erratum text, but the links are not live.</p><p>A number of indexes appear at the end of the document.</p><p>Substantive corrections are proposed by the
-	     <a href="http://www.w3.org/XML/Query">XML Query Working Group</a>
-         (part of the <a href="http://www.w3.org/XML/Activity">XML Activity</a>),
-         where there is consensus that they are appropriate;
-         they are not to be considered normative until approved by a
-         <a href="http://www.w3.org/2004/02/Process-20040205/tr.html#cfr-corrections">Call
-         for Review of Proposed Corrections</a> or a
-         <a href="http://www.w3.org/2004/02/Process-20040205/tr.html#cfr-edited">Call
-         for Review of an Edited Recommendation</a>. </p><p>Please report errors in this document using W3C's 
-		 <a href="http://www.w3.org/Bugs/Public/">public Bugzilla system</a> 
-		 (instructions can be found at 
-		 <a href="http://www.w3.org/XML/2005/04/qt-bugzilla">http://www.w3.org/XML/2005/04/qt-bugzilla</a>).
-		 If access to that system is not feasible, you may send your comments to the
-         W3C XSLT/XPath/XQuery public comments mailing list,
-         <a href="mailto:public-qt-comments@w3.org">public-qt-comments@w3.org</a>. 
-         It will be very helpful if you include the string
-         [XQ31errata]
-         in the subject line of your report, whether made in Bugzilla or in email.
-		 Each Bugzilla entry and email message should contain only one error report. 
-         Archives of the comments and responses are available at
-         <a href="http://lists.w3.org/Archives/Public/public-qt-comments/">
-         http://lists.w3.org/Archives/Public/public-qt-comments/</a>. 
-	</p></div><div><h2><a name="status" id="status"></a>Status of this Document</h2><p><em>This is an editor's draft. </em>
-		  None of the errata reported in this document have been approved
-		  by a <a href="http://www.w3.org/2004/02/Process-20040205/tr.html#cfr-corrections">Call for Review of Proposed Corrections</a> or a
-		  <a href="http://www.w3.org/2004/02/Process-20040205/tr.html#cfr-edited">Call for Review of an Edited Recommendation</a>. 
-		  As a consequence, they must not be considered to be normative.
-		  </p><p>The Working Group does not intend to progress these errata to normative status; instead, it
-		  intends to publish a second edition of the Recommendation incorporating these errata, and to progress
-		  the second edition to normative status.</p></div><div><h2><a name="contents" id="contents"></a>Table of Contents</h2><p>&nbsp;&nbsp;<b>Errata</b></p><p>&nbsp;&nbsp;&nbsp;&nbsp;
+	in the erratum text, but the links are not live.</p><p>A number of indexes appear at the end of the document.</p>
+    </div>
+    <div><h2><a name="status" id="status"></a>Status of this Document</h2><p><em>This is a public draft.</em>
+        It is maintained in accordance with the W3C process on <a href="https://www.w3.org/2017/Process-20170301/#errata">Errata Management</a>.
+        None of the errata reported in this document must be considered normative.
+    </p></div>
+
+    <div><h2><a name="contents" id="contents"></a>Table of Contents</h2><p>&nbsp;&nbsp;<b>Errata</b></p><p>&nbsp;&nbsp;&nbsp;&nbsp;
 	    <a href="#E4">XQ31.E4</a>&nbsp;&nbsp;
 		Some examples in the section concerned with the unary lookup operator are actually examples of postfix lookup.</p><p>&nbsp;&nbsp;&nbsp;&nbsp;
 	    <a href="#E3">XQ31.E3</a>&nbsp;&nbsp;
@@ -312,7 +290,7 @@ a.env:visited, a.env:link               { color: black;
 		The term "Query Environment" (used in the definition of external functions) is not explained; furthermore it is used in XPath as well as XQuery.</p><p>&nbsp;&nbsp;&nbsp;&nbsp;
 	    <a href="#E1">XQ31.E1</a>&nbsp;&nbsp;
 		The introductory section on Atomizations mentions that FOTY0012 can be raised, but other errors (for example, FOTY0013) are also possible.</p><p>&nbsp;&nbsp;<b>Indexes</b></p><p>&nbsp;&nbsp;&nbsp;&nbsp;<a href="#index-by-section">Index by affected section</a></p><p>&nbsp;&nbsp;&nbsp;&nbsp;<a href="#index-by-bugzilla">Index by Bugzilla entry</a></p><p>&nbsp;&nbsp;&nbsp;&nbsp;<a href="#index-by-error">Index by
-	        error</a></p></div><hr><h2><a id="E4" name="E4">XQ31.E4 - editorial</a></h2><p><i>See <a href="http://www.w3.org/Bugs/Public/show_bug.cgi?id=30175">Bug 30175</a></i></p><h3>Description</h3><p>Some examples in the section concerned with the unary lookup operator are actually
+	        error</a></p></div><hr><h2><a id="E4" name="E4">XQ31.E4 - editorial</a></h2><p><i>See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=30175">Bug 30175</a></i></p><h3>Description</h3><p>Some examples in the section concerned with the unary lookup operator are actually
 				examples of postfix lookup.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Changes</h3><ol><li><p>In 3.11.3.1 Unary Lookup (first bulleted list, ninth item):</p><p><i>Delete the text:</i></p><div style="border: medium double rgb(255,0,0)"><ul><li><p>If <code>$m</code> is bound to the weekdays map described in <span style="text-decoration: underline">3.11.1 Maps</span>, then <code>$m?*</code> returns the values
                               <code>("Sunday","Monday","Tuesday","Wednesday", "Thursday",
                               "Friday","Saturday")</code>, in <span style="text-decoration: underline">implementation-dependent</span>
@@ -339,7 +317,7 @@ a.env:visited, a.env:link               { color: black;
 						<code>[1, 2, 5, 7]?*</code> evaluates to <code>(1, 2, 5, 7)</code>.</p></li></ul><ul><li><p>
 						<code>[[1, 2, 3], [4, 5, 6]]?*</code> evaluates to <code>([1, 2, 3], [4,
 							5, 6])</code>
-					</p></li></ul></div></li></ol><h2><a id="E3" name="E3">XQ31.E3 - editorial</a></h2><p><i>See <a href="http://www.w3.org/Bugs/Public/show_bug.cgi?id=30169">Bug 30169</a></i></p><h3>Description</h3><p>The definition of "pure union types" is unnecessarily complex.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Change</h3><p>In 2.5 Types (fifth paragraph):</p><p><i>Replace the text:</i></p><div style="border: medium double rgb(255,0,0)"><p>
+					</p></li></ul></div></li></ol><h2><a id="E3" name="E3">XQ31.E3 - editorial</a></h2><p><i>See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=30169">Bug 30169</a></i></p><h3>Description</h3><p>The definition of "pure union types" is unnecessarily complex.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Change</h3><p>In 2.5 Types (fifth paragraph):</p><p><i>Replace the text:</i></p><div style="border: medium double rgb(255,0,0)"><p>
                <span class="termdef"><a id="dt-pure-union-type"></a>[Definition]  A <b>pure union
                      type</b> is an XML Schema union type that satisfies the following
                   constraints: (1) <code>{variety}</code> is <code>union</code>, (2) the
@@ -354,7 +332,7 @@ a.env:visited, a.env:link               { color: black;
 						constraints: (1) <code>{variety}</code> is <code>union</code>, (2) 
 						<code>{facets}</code> is empty, (3) each type in its transitive
 						membership is a <span style="text-decoration: underline">generalized atomic type</span>.</span></p><div class="note"><p class="prefix"><b>Note:</b></p><p>The term <b>transitive membership</b> is defined in [XML Schema 1.1 Part 2]; the
-				definition is equally applicable to XSD 1.0.</p></div></div><h2><a id="E2" name="E2">XQ31.E2 - editorial</a></h2><p><i>See <a href="http://www.w3.org/Bugs/Public/show_bug.cgi?id=30155">Bug 30155</a></i></p><h3>Description</h3><p>The term "Query Environment" (used in the definition of external functions) is not explained; furthermore it
+				definition is equally applicable to XSD 1.0.</p></div></div><h2><a id="E2" name="E2">XQ31.E2 - editorial</a></h2><p><i>See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=30155">Bug 30155</a></i></p><h3>Description</h3><p>The term "Query Environment" (used in the definition of external functions) is not explained; furthermore it
 				is used in XPath as well as XQuery. This erratum fixes the problem by defining external functions without
 			reference to the concept.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Change</h3><p>In 2.1.2 Dynamic Context (first bulleted list, fifth item):</p><p><i>Replace the text:</i></p><div style="border: medium double rgb(255,0,0)"><p>
                         <span class="termdef"><a id="dt-named-functions"></a>[Definition]  
@@ -404,7 +382,7 @@ a.env:visited, a.env:link               { color: black;
 								function</b> is an <span style="text-decoration: underline">external function</span> that is
 							<span style="text-decoration: underline">implementation-defined</span>
 						</span>. 
-				</p></div><h2><a id="E1" name="E1">XQ31.E1 - editorial</a></h2><p><i>See <a href="http://www.w3.org/Bugs/Public/show_bug.cgi?id=30153">Bug 30153</a></i></p><h3>Description</h3><p>The introductory section on Atomizations mentions that FOTY0012 can be raised, but other errors (for example, FOTY0013) 
+				</p></div><h2><a id="E1" name="E1">XQ31.E1 - editorial</a></h2><p><i>See <a href="https://www.w3.org/Bugs/Public/show_bug.cgi?id=30153">Bug 30153</a></i></p><h3>Description</h3><p>The introductory section on Atomizations mentions that FOTY0012 can be raised, but other errors (for example, FOTY0013)
 		  	are also possible.</p><h3>History</h3><p><b>13 Oct 2017: </b>Proposed</p><h3>Change</h3><p>In 2.4.2 Atomization (first paragraph):</p><p><i>Replace the text:</i></p><div style="border: medium double rgb(255,0,0)"><p>The semantics of some XQuery 3.1 operators depend on a process called <span style="text-decoration: underline">atomization</span>. Atomization is applied to a value
                   when the value is used in a context in which a sequence of atomic values is
                   required. The result of atomization is either a sequence of atomic values or a


### PR DESCRIPTION
This PR prepares the XPath & XQuery errata documents created by @michaelhkay for publication.
- changed hrefs from http: to https:
- corrected link to specs
- updated status section to refer to 2017 process document

@michaelhkay I believe you generated these HTML pages from a source XML and a stylesheet.  Please could you add these to this repo with instructions on how to build them?

@liamquin please could you copy the HTML files to their final resting place?:
- https://www.w3.org/XML/2017/qt-errata/xquery-31-errata.html
- https://www.w3.org/XML/2017/qt-errata/xpath-31-errata.html