### PR TITLE
fixup hrefs in namespace documents - bugzilla 30189

### DIFF
--- a/specifications/xquery-31/html/ns-local.html
+++ b/specifications/xquery-31/html/ns-local.html
@@ -33,11 +33,11 @@ Document</h1>
 <p>This document describes the namespace
 <code>http://www.w3.org/2005/xquery-local-functions</code> defined
 by the <a href="#xquery-31-ref">[XQuery 3.1]</a> specification
-(December 2015 version). This namespace is identified by the
-namespace prefix <code>local:</code>, which is a predefined prefix,
-but it is not defined by an XML schema. For updated information,
-please refer to the latest version of the <a href=
-"#xquery-31-ref">[XQuery 3.1]</a> specification.</p>
+(March 2017 version). This namespace is identified by the namespace
+prefix <code>local:</code>, which is a predefined prefix, but it is
+not defined by an XML schema. For updated information, please refer
+to the latest version of the <a href="#xquery-31-ref">[XQuery
+3.1]</a> specification.</p>
 <p>This document describes the intended uses of this namespace. The
 W3C reserves the right to define names in this namespace in the
 future. <a href="#xquery-31-ref">[XQuery 3.1]</a> is the
@@ -65,8 +65,8 @@ References</h2>
 <dd>
 <div class="resource">
 <p><a href=
-"http://www.w3.org/TR/2015/CR-xquery-31-20151217/">XQuery 3.1</a>
-(17 December 2015 version)</p>
+"https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a>
+(21 March 2017 version)</p>
 <p>This document describes the usage of this namespace. The W3C
 reserves the right to define names in this namespace in the future.
 <a href="#xquery-31-ref">[XQuery 3.1]</a> is the <em>only</em>

--- a/specifications/xquery-31/html/ns-local.rdf
+++ b/specifications/xquery-31/html/ns-local.rdf
@@ -16,8 +16,8 @@
    <owl:Ontology rdf:about="rddl.owl"/>
    <rdf:Description rdf:about="http://www.w3.org/2005/xquery-local-functions">
       <rdf:type rdf:resource="http://www.w3.org/2007/ont/link#Document"/>
-            XQuery 3.1 (17 December
-              2015 version)
+            XQuery 3.1 (21 March
+              2017 version)
           
             Resource Directory Description Language (RDDL)
               (4 July 2007)

--- a/specifications/xquery-31/html/ns-local.xhtml
+++ b/specifications/xquery-31/html/ns-local.xhtml
@@ -26,7 +26,7 @@
             
             <h2><a name="intro" id="intro"></a>1 Introduction
             </h2>
-            <p> This document describes the namespace <code>http://www.w3.org/2005/xquery-local-functions</code> defined by the <a href="#xquery-31-ref">[XQuery 3.1]</a> specification (December 2015 version).
+            <p> This document describes the namespace <code>http://www.w3.org/2005/xquery-local-functions</code> defined by the <a href="#xquery-31-ref">[XQuery 3.1]</a> specification (March 2017 version).
                This namespace is identified by the namespace prefix <code>local:</code>, which is a
                predefined prefix, but it is not defined by an XML schema. For updated information,
                please
@@ -60,10 +60,10 @@
                <dd>
                   <div class="resource">
                      
-                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="http://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="https://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                         
-                        <p><a href="http://www.w3.org/TR/2015/CR-xquery-31-20151217/">XQuery 3.1</a> (17 December
-                           2015 version)
+                        <p><a href="https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a> (21 March
+                           2017 version)
                         </p>
                         
                      </rddl:resource>

--- a/specifications/xquery-31/html/ns-xquery.html
+++ b/specifications/xquery-31/html/ns-xquery.html
@@ -35,7 +35,7 @@ Features Namespace Document</h1>
 <h2><a name="intro" id="intro"></a>1 Introduction</h2>
 <p>This document describes the namespace
 <code>http://www.w3.org/2012/xquery</code> defined by the <a href=
-"#xquery-31-ref">[XQuery 3.1]</a> specification (December 2015
+"#xquery-31-ref">[XQuery 3.1]</a> specification (March 2017
 version). This namespace is identified in this document by the
 namespace prefix <code>qfa:</code>, but that is <em>not</em> a
 predefined namespace prefix; this namespace is not defined by an
@@ -155,8 +155,8 @@ References</h2>
 <dd>
 <div class="resource">
 <p><a href=
-"http://www.w3.org/TR/2015/CR-xquery-31-20151217/">XQuery 3.1</a>
-(17 December 2015 version)</p>
+"https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a>
+(21 March 2017 version)</p>
 <p>This document describes the usage of this namespace. The W3C
 reserves the right to define names in this namespace in the future.
 <a href="#xquery-31-ref">[XQuery 3.1]</a> is the <em>only</em>

--- a/specifications/xquery-31/html/ns-xquery.rdf
+++ b/specifications/xquery-31/html/ns-xquery.rdf
@@ -26,8 +26,8 @@
           [XQuery 3.1] defines two features that are used to control the use of
           other, optional features. 
       
-            XQuery 3.1 (17 December
-              2015 version)
+            XQuery 3.1 (21 March
+              2017 version)
           
             Resource Directory Description Language (RDDL)
               (4 July 2007)

--- a/specifications/xquery-31/html/ns-xquery.xhtml
+++ b/specifications/xquery-31/html/ns-xquery.xhtml
@@ -28,7 +28,7 @@
             
             <h2><a name="intro" id="intro"></a>1 Introduction
             </h2>
-            <p> This document describes the namespace <code>http://www.w3.org/2012/xquery</code> defined by the <a href="#xquery-31-ref">[XQuery 3.1]</a> specification (December 2015 version).
+            <p> This document describes the namespace <code>http://www.w3.org/2012/xquery</code> defined by the <a href="#xquery-31-ref">[XQuery 3.1]</a> specification (March 2017 version).
                This namespace is identified in this document by the namespace prefix <code>qfa:</code>, but
                that is <em>not</em> a predefined namespace prefix; this namespace is not defined by an
                XML Schema. For updated information, please refer to the latest version of the <a href="#xquery-31-ref">[XQuery 3.1]</a> specification. 
@@ -51,7 +51,7 @@
             
             <h2><a name="features" id="features"></a>2 XQuery Annotations
             </h2>
-            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery Annotations" xlink:role="http://www.rddl.org/natures#term" xlink:arcrole="http://www.rddl.org/purposes#definition" xlink:href="http://www.w3.org/TR/2015/CR-xquery-31-20151217/#id-annotations" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery Annotations" xlink:role="http://www.rddl.org/natures#term" xlink:arcrole="http://www.rddl.org/purposes#definition" xlink:href="https://www.w3.org/TR/2017/REC-xquery-31-20170321/#id-annotations" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                
                <p>
                   <a href="#xquery-31-ref">[XQuery 3.1]</a> provides syntax to define annotations on function
@@ -82,7 +82,7 @@
             
             <h2><a name="features" id="features"></a>3 XQuery Features
             </h2>
-            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery Features" xlink:role="http://www.rddl.org/natures#term" xlink:arcrole="http://www.rddl.org/purposes#definition" xlink:href="http://www.w3.org/TR/2015/CR-xquery-31-20151217/#id-conform-optional-features" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery Features" xlink:role="http://www.rddl.org/natures#term" xlink:arcrole="http://www.rddl.org/purposes#definition" xlink:href="https://www.w3.org/TR/2017/REC-xquery-31-20170321/#id-conform-optional-features" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                
                <p>
                   <a href="#xquery-31-ref">[XQuery 3.1]</a> defines two features that are used to control the use of
@@ -147,10 +147,10 @@
                <dd>
                   <div class="resource">
                      
-                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="http://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="https://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                         
-                        <p><a href="http://www.w3.org/TR/2015/CR-xquery-31-20151217/">XQuery 3.1</a> (17 December
-                           2015 version)
+                        <p><a href="https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a> (21 March
+                           2017 version)
                         </p>
                         
                      </rddl:resource>

--- a/specifications/xquery-31/src/ns-features.xml
+++ b/specifications/xquery-31/src/ns-features.xml
@@ -1,21 +1,32 @@
 <?xml version="1.0"?>
 <!DOCTYPE spec SYSTEM "../../../schema/qtnamespaces.dtd" [
-<!ENTITY doc.date.day "1">
-<!ENTITY doc.date.month "October">
-<!ENTITY doc.date.MM "10">
+<!ENTITY doc.date.day "21">
+<!ENTITY doc.date.month "March">
+<!ENTITY doc.date.MM "03">
+<!ENTITY doc.date.year "2017">
 <!ENTITY doc.nsname "xquery-features">
 <!ENTITY doc.publoc "http://www.w3.org/2005/&doc.nsname;">
+
+<!ENTITY xq.spec.date.day "21">
+<!ENTITY xq.spec.date.month "March">
+<!ENTITY xq.spec.date.MM "03">
+<!ENTITY xq.spec.date.year "2017">
+<!ENTITY xq.spec.ver "31">
+<!ENTITY xq.spec.doctype "REC">
+<!ENTITY xq.spec.name "xquery">
+<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&xq.spec.ver;">
+<!ENTITY xq.loc.dated     "https://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
 ]>
-<spec w3c-doctype="wd" status="ext-review">
+<spec w3c-doctype="rec" status="ext-review">
   <header>
     <title>XQuery 3.1 Features Namespace Document</title>
     <version/>
     <w3c-designation/>
-    <w3c-doctype>W3C Working Draft</w3c-doctype>
+    <w3c-doctype>W3C Recommendation</w3c-doctype>
     <pubdate>
-      <day>&date.day;</day>
-      <month>&date.month;</month>
-      <year>&date.year;</year>
+      <day>&doc.date.day;</day>
+      <month>&doc.date.month;</month>
+      <year>&doc.date.year;</year>
     </pubdate>
     <publoc>
       <loc href="&doc.publoc;">&doc.publoc;</loc>
@@ -50,8 +61,8 @@
       <head>Introduction</head>
 
       <p> This document describes the namespace <code>http://www.w3.org/2011/xquery-features</code>
-        defined by the <bibref ref="xquery-31-ref"/> specification (Last Call Working Draft
-        of 1 October 2014). This namespace is frequently identified by the namespace prefix
+        defined by the <bibref ref="xquery-31-ref"/> specification (&xq.spec.date.month; &xq.spec.date.year; version).
+        This namespace is frequently identified by the namespace prefix
           <code>qf:</code>, but that is not a predefined namespace prefix; this namespace is not
         defined by an XML Schema. For updated information, please refer to the latest version of the
           <bibref ref="xquery-31-ref"/> specification. </p>
@@ -76,7 +87,7 @@
 
       <rddl:resource xlink:title="XQuery Features" xlink:role="http://www.rddl.org/natures#term"
         xlink:arcrole="http://www.rddl.org/purposes#definition"
-        xlink:href="http://www.w3.org/TR/2014/WD-xquery-31-20141001/#id-conform-optional-features">
+        xlink:href="https://www.w3.org/TR/&xq.spec.name;-&xq.spec.ver;/#id-conform-optional-features">
         <p>
           <bibref ref="xquery-31-ref"/> defines two features that are used to control the use of
           other, optional features. </p>
@@ -138,9 +149,9 @@
           <rddl:resource xlink:title="XQuery 3.1"
             xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional"
             xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference"
-            xlink:href="http://www.w3.org/TR/xquery-31/">
-            <p><loc href="http://www.w3.org/TR/2014/WD-xquery-31-20141001/">XQuery 3.1</loc>
-              (First Public Working Draft of 1 October 2014)</p>
+            xlink:href="&xq.loc;">
+            <p><loc href="&xq.loc.dated;">XQuery 3.1</loc>
+              (&xq.spec.date.day; &xq.spec.date.month; &xq.spec.date.year; version)</p>
             <p>This document describes the usage of this namespace. The W3C reserves the right to
               define names in this namespace in the future. <bibref ref="xquery-31-ref"/> is the
                 <emph>only</emph> specification that is permitted to amend this namespace. It may,

--- a/specifications/xquery-31/src/ns-local.xml
+++ b/specifications/xquery-31/src/ns-local.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <!DOCTYPE spec SYSTEM "../../../schema/qtnamespaces.dtd" [
-<!ENTITY doc.date.day "17">
-<!ENTITY doc.date.month "December">
-<!ENTITY doc.date.MM "12">
-<!ENTITY doc.date.year "2015">
+<!ENTITY doc.date.day "21">
+<!ENTITY doc.date.month "March">
+<!ENTITY doc.date.MM "03">
+<!ENTITY doc.date.year "2017">
 <!ENTITY doc.nsname "xquery-local-functions">
 <!ENTITY doc.publoc "http://www.w3.org/2005/&doc.nsname;">
 <!ENTITY nsname     "http://www.w3.org/2005/&doc.nsname;">
 
-<!ENTITY xq.spec.date.day "17">
-<!ENTITY xq.spec.date.month "December">
-<!ENTITY xq.spec.date.MM "12">
-<!ENTITY xq.spec.date.year "2015">
+<!ENTITY xq.spec.date.day "21">
+<!ENTITY xq.spec.date.month "March">
+<!ENTITY xq.spec.date.MM "03">
+<!ENTITY xq.spec.date.year "2017">
 <!ENTITY xq.spec.ver "31">
-<!ENTITY xq.spec.doctype "CR">
+<!ENTITY xq.spec.doctype "REC">
 <!ENTITY xq.spec.name "xquery">
-<!ENTITY xq.loc     "http://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
-<!ENTITY xq.loc.dated     "http://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
+<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
+<!ENTITY xq.loc.dated     "https://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
 ]>
-<spec w3c-doctype="cr" status="ext-review">
+<spec w3c-doctype="rec" status="ext-review">
   <header>
     <title>XQuery Local Functions Namespace Document</title>
     <version/>
     <w3c-designation/>
-    <w3c-doctype>W3C Candidate Recommendation</w3c-doctype>
+    <w3c-doctype>W3C Recommendation</w3c-doctype>
     <pubdate>
       <day>&doc.date.day;</day>
       <month>&doc.date.month;</month>

--- a/specifications/xquery-31/src/ns-xquery.xml
+++ b/specifications/xquery-31/src/ns-xquery.xml
@@ -1,29 +1,29 @@
 <?xml version="1.0"?>
 <!DOCTYPE spec SYSTEM "../../../schema/qtnamespaces.dtd" [
-<!ENTITY doc.date.day "17">
-<!ENTITY doc.date.month "December">
-<!ENTITY doc.date.MM "12">
-<!ENTITY doc.date.year "2015">
+<!ENTITY doc.date.day "21">
+<!ENTITY doc.date.month "March">
+<!ENTITY doc.date.MM "03">
+<!ENTITY doc.date.year "2017">
 <!ENTITY doc.nsname "xquery">
 <!ENTITY doc.publoc "http://www.w3.org/2012/&doc.nsname;">
 <!ENTITY nsname     "http://www.w3.org/2012/&doc.nsname;">
 
-<!ENTITY xq.spec.date.day "17">
-<!ENTITY xq.spec.date.month "December">
-<!ENTITY xq.spec.date.MM "12">
-<!ENTITY xq.spec.date.year "2015">
+<!ENTITY xq.spec.date.day "21">
+<!ENTITY xq.spec.date.month "March">
+<!ENTITY xq.spec.date.MM "03">
+<!ENTITY xq.spec.date.year "2017">
 <!ENTITY xq.spec.ver "31">
-<!ENTITY xq.spec.doctype "CR">
+<!ENTITY xq.spec.doctype "REC">
 <!ENTITY xq.spec.name "xquery">
-<!ENTITY xq.loc     "http://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
-<!ENTITY xq.loc.dated     "http://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
+<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
+<!ENTITY xq.loc.dated     "https://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
 ]>
-<spec w3c-doctype="cr" status="ext-review">
+<spec w3c-doctype="rec" status="ext-review">
   <header>
     <title>XQuery Annotations and Optional Features Namespace Document</title>
     <version/>
     <w3c-designation/>
-    <w3c-doctype>W3C Candidate Recommendation</w3c-doctype>
+    <w3c-doctype>W3C Recommendation</w3c-doctype>
     <pubdate>
       <day>&doc.date.day;</day>
       <month>&doc.date.month;</month>

--- a/specifications/xqueryx-31/build/ns-xqueryx.html
+++ b/specifications/xqueryx-31/build/ns-xqueryx.html
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="utf-8"?><!--XSLT Processor: Saxonica SAXON HE 9.6.0.7--><html lang="EN"><head><title>XQueryX 3.1 Namespace Document </title><style xmlns:rddl="http://www.rddl.org/" type="text/css"> </style><link xmlns:rddl="http://www.rddl.org/" rel="stylesheet" type="text/css" href="http://www.w3.org/StyleSheets/TR/base.css"/></head><body><div xmlns:rddl="http://www.rddl.org/" class="head"><p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72"/></a></p><h1><a name="title" id="title"/>XQueryX 3.1 Namespace Document</h1></div><div class="toc">
+<h2><a name="contents" id="contents"/>Table of Contents</h2><p class="toc">1 <a href="#intro">Introduction</a><br/>
+2 <a href="#schemas">XML Schema</a><br/>
+3 <a href="#stylesheet">XSLT Stylesheet</a><br/>
+4 <a href="#normrefs">Normative References</a><br/>
+5 <a href="#nonnormrefs">Non-Normative References</a><br/>
+</p></div><hr/><div class="body"><div xmlns:rddl="http://www.rddl.org/">
+<h2><a name="intro" id="intro"/>1 Introduction</h2><p>
+This document describes the namespace
+<code>http://www.w3.org/2005/XQueryX</code> defined by the
+<a href="#xqueryx-31-ref">[XQueryX 3.1]</a> specification
+(March 2017 version). 
+This namespace is typically identified by the namespace prefix <code>xqx:</code>,
+which is <em>not</em> a predefined prefix. 
+For updated information, please refer to the latest version of the
+<a href="#xqueryx-31-ref">[XQueryX 3.1]</a> specification.
+</p><p>
+This document contains a directory of links to related resources, using RDDL
+(as defined in <a href="#rddl-ref">[Resource Directory Description Language (RDDL)]</a>). 
+</p><p>
+It is GRDDL-enabled (as defined in <a href="#grddl-ref">[Gleaning Resource Descriptions from Dialects of Languages (GRDDL)]</a>), that is to
+say that a GRDDL-compliant processor can extract useful RDF
+(as defined in <a href="#rdf-ref">[Resource Description Framework (RDF): Concepts and Abstract Syntax]</a>)
+representations of the information contained herein.
+</p></div><div xmlns:rddl="http://www.rddl.org/" class="resource">
+<h2><a name="schemas" id="schemas"/>2 XML Schema</h2><p>
+There are two syntaxes in which <a href="#xquery-31-ref">[XQuery 3.1]</a>
+queries can be written. 
+One is the so-called human-readable syntax defined by
+<a href="#xquery-31-ref">[XQuery 3.1]</a>,
+while the other is an XML syntax for XQuery defined by
+<a href="#xqueryx-31-ref">[XQueryX 3.1]</a>. 
+</p><p>
+XQueryX, as defined in <a href="#xqueryx-31-ref">[XQueryX 3.1]</a>,
+is specified in the namespace <code>http://www.w3.org/2005/XQueryX</code>, which
+is defined by an XML Schema. 
+</p><rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="XML Schema for validation" xlink:role="http://www.w3.org/2001/XMLSchema" xlink:arcrole="http://www.rddl.org/purposes#schema-validation" xlink:href="http://www.w3.org/2017/03/XQueryX/xqueryx.xsd" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p>
+This schema specifies the XML syntax of the XQuery expressions defined in
+<a href="#xquery-31-ref">[XQuery 3.1]</a>. 
+It is located at
+<a href="http://www.w3.org/2017/03/XQueryX/xqueryx.xsd">http://www.w3.org/2017/03/XQueryX/xqueryx.xsd</a>.
+</p>
+</rddl:resource><p>
+XQuery 3.1 queries written using the XML syntax must be valid according to that schema. 
+Validation must be performed as defined by <a href="#schema1-ref">[XML Schema Part 1: Structures Second Edition]</a>,
+using strict validation, full validation attempted, using the <code>&lt;xqx:module&gt;</code>
+element as the validation root. 
+The result of that validation must not be invalid or notKnown. 
+</p></div><div xmlns:rddl="http://www.rddl.org/" class="resource">
+<h2><a name="stylesheet" id="stylesheet"/>3 XSLT Stylesheet</h2><rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="XSLT stylesheet for transformation into human-readable syntax" xlink:role="http://www.isi.edu/in-notes/iana/assignments/media-types/application/xslt+xml" xlink:arcrole="http://www.w3.org/1999/XSL/Transform" xlink:href="http://www.w3.org/2017/03/XQueryX/xqueryx.xsl" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p>
+Queries written using the XML syntax of <a href="#xquery-31-ref">[XQuery 3.1]</a> have semantics
+that are defined by the XQuery "human-readable" syntax that results from transforming
+those XML syntax queries using the stylesheet located at
+<a href="http://www.w3.org/2017/03/XQueryX/xqueryx.xsl">http://www.w3.org/2017/03/XQueryX/xqueryx.xsl</a>. 
+</p>
+</rddl:resource></div><div xmlns:rddl="http://www.rddl.org/">
+<h2><a name="normrefs" id="normrefs"/>4 Normative References</h2><dl><dt class="label"><span><a name="xqueryx-31-ref" id="xqueryx-31-ref"/>XQueryX 3.1</span></dt><dd><div class="resource">
+<rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="XQueryX 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="http://www.w3.org/TR/2017/WD-xqueryx-31-20170321/" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p>
+<a href="http://www.w3.org/TR/2017/REC-xqueryx-31-20170321/">XQueryX 3.1</a>
+(21 March 2017 version)
+</p>
+
+<p>This document describes the names that are defined in this namespace at the time of publication. 
+The W3C reserves the right to define additional names in this namespace in the future. 
+<a href="#xqueryx-31-ref">[XQueryX 3.1]</a>
+is the <em>only</em> specification that is permitted to amend this namespace.
+It may, however, be augmented by other specifications that define XQueryX 3.1 extensions
+corresponding to XQuery 3.1 extensions. 
+</p>
+</rddl:resource>
+</div></dd></dl></div><div xmlns:rddl="http://www.rddl.org/">
+<h2><a name="nonnormrefs" id="nonnormrefs"/>5 Non-Normative References</h2><dl><dt class="label"><span><a name="xquery-31-requirements-ref" id="xquery-31-requirements-ref"/>XQuery 3.1 Requirements and Use Cases</span></dt><dd><div class="resource">
+<rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="XQuery 3.1 Requirements and Use Cases" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/xquery-31-requirements" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p><a href="http://www.w3.org/TR/2016/NOTE-xquery-31-requirements-20161213/">XQuery 3.1 Requirements</a>
+(13 December 2016 version)</p>
+</rddl:resource>
+</div></dd><dt class="label"><span><a name="xquery-31-ref" id="xquery-31-ref"/>XQuery 3.1</span></dt><dd><div class="resource">
+<rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p><a href="http://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a>
+(21 March 2017 version)</p>
+</rddl:resource>
+</div></dd><dt class="label"><span><a name="rddl-ref" id="rddl-ref"/>Resource Directory Description Language (RDDL)</span></dt><dd><div class="resource">
+<rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="Resource Directory Description Language (RDDL)" xlink:role="http://www.w3.org/TR/xhtml-basic" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.rddl.org/20050704/" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p><a href="http://www.rddl.org/">Resource Directory Description Language (RDDL)</a> (4 July 2007)</p>
+</rddl:resource>
+</div></dd><dt class="label"><span><a name="grddl-ref" id="grddl-ref"/>Gleaning Resource Descriptions from Dialects of Languages (GRDDL)</span></dt><dd><div class="resource">
+<rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="Gleaning Resource Descriptions from Dialects of Languages (GRDDL)" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/2007/REC-grddl-20070911/" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p><a href="http://www.w3.org/TR/grddl/">Gleaning Resource Descriptions from Dialects of Languages (GRDDL)</a>
+(Recommendation of 11 September 2007)</p>
+</rddl:resource>
+</div></dd><dt class="label"><span><a name="rdf-ref" id="rdf-ref"/>Resource Description Framework (RDF): Concepts and Abstract Syntax</span></dt><dd><div class="resource">
+<rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="Resource Description Framework (RDF): Concepts and Abstract Syntax" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/2004/REC-rdf-concepts-20040210/" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p><a href="http://www.w3.org/TR/rdf-concepts/">Resource Description Framework (RDF):
+Concepts and Abstract Syntax</a> (Recommendation of 10 February 2004)</p>
+</rddl:resource>
+</div></dd><dt class="label"><span><a name="schema1-ref" id="schema1-ref"/>XML Schema Part 1: Structures Second Edition</span></dt><dd><div class="resource">
+<rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xlink:title="XML Schema Part 1: Structures Second Edition" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/xmlschema-1/" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+<p><a href="http://www.w3.org/TR/2004/REC-xmlschema-1-20041028/">XML Schema Part 1: Structures Second Edition</a>
+(Recommendation of 28 October 2004)</p>
+</rddl:resource>
+</div></dd></dl></div></div></body></html>

--- a/specifications/xqueryx-31/html/ns-xqueryx.html
+++ b/specifications/xqueryx-31/html/ns-xqueryx.html
@@ -34,7 +34,7 @@ Document</h1>
 <h2><a name="intro" id="intro"></a>1 Introduction</h2>
 <p>This document describes the namespace
 <code>http://www.w3.org/2005/XQueryX</code> defined by the <a href=
-"#xqueryx-31-ref">[XQueryX 3.1]</a> specification (October 2014
+"#xqueryx-31-ref">[XQueryX 3.1]</a> specification (March 2017
 version). This namespace is typically identified by the namespace
 prefix <code>xqx:</code>, which is <em>not</em> a predefined
 prefix. For updated information, please refer to the latest version
@@ -65,7 +65,7 @@ XML Schema.</p>
 <p>This schema specifies the XML syntax of the XQuery expressions
 defined in <a href="#xquery-31-ref">[XQuery 3.1]</a>. It is located
 at <a href=
-"http://www.w3.org/2014/10/XQueryX/xqueryx.xsd">http://www.w3.org/2014/10/XQueryX/xqueryx.xsd</a>.</p>
+"http://www.w3.org/2017/03/XQueryX/xqueryx.xsd">http://www.w3.org/2017/03/XQueryX/xqueryx.xsd</a>.</p>
 <p>XQuery 3.1 queries written using the XML syntax must be valid
 according to that schema. Validation must be performed as defined
 by <a href="#schema1-ref">[XML Schema Part 1: Structures Second
@@ -81,7 +81,7 @@ notKnown.</p>
 by the XQuery "human-readable" syntax that results from
 transforming those XML syntax queries using the stylesheet located
 at <a href=
-"http://www.w3.org/2014/10/XQueryX/xqueryx.xsl">http://www.w3.org/2014/10/XQueryX/xqueryx.xsl</a>.</p>
+"http://www.w3.org/2017/03/XQueryX/xqueryx.xsl">http://www.w3.org/2017/03/XQueryX/xqueryx.xsl</a>.</p>
 </div>
 <div>
 <h2><a name="normrefs" id="normrefs"></a>4 Normative
@@ -92,8 +92,8 @@ References</h2>
 <dd>
 <div class="resource">
 <p><a href=
-"http://www.w3.org/TR/2014/WD-xqueryx-31-2014101/">XQueryX 3.1</a>
-(1 October 2014 version)</p>
+"https://www.w3.org/TR/2017/REC-xqueryx-31-20170321/">XQueryX
+3.1</a> (21 March 2017 version)</p>
 <p>This document describes the names that are defined in this
 namespace at the time of publication. The W3C reserves the right to
 define additional names in this namespace in the future. <a href=
@@ -115,16 +115,17 @@ Cases</span></dt>
 <dd>
 <div class="resource">
 <p><a href=
-"http://www.w3.org/TR/2014/WD-xquery-31-requirements-2014101/">XQuery
-3.1 Requirements</a> (1 October 2014 version)</p>
+"https://www.w3.org/TR/2016/NOTE-xquery-31-requirements-20161213/">XQuery
+3.1 Requirements</a> (13 December 2016 version)</p>
 </div>
 </dd>
 <dt class="label"><span><a name="xquery-31-ref" id=
 "xquery-31-ref"></a>XQuery 3.1</span></dt>
 <dd>
 <div class="resource">
-<p><a href="http://www.w3.org/TR/2014/WD-xquery-31-2014101/">XQuery
-3.1</a> (1 October 2014 version)</p>
+<p><a href=
+"https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a>
+(21 March 2017 version)</p>
 </div>
 </dd>
 <dt class="label"><span><a name="rddl-ref" id=

--- a/specifications/xqueryx-31/html/ns-xqueryx.rdf
+++ b/specifications/xqueryx-31/html/ns-xqueryx.rdf
@@ -20,19 +20,19 @@
 This schema specifies the XML syntax of the XQuery expressions defined in
 [XQuery 3.1]. 
 It is located at
-http://www.w3.org/2014/10/XQueryX/xqueryx.xsd.
+http://www.w3.org/2017/03/XQueryX/xqueryx.xsd.
 
 
 
 Queries written using the XML syntax of [XQuery 3.1] have semantics
 that are defined by the XQuery "human-readable" syntax that results from transforming
 those XML syntax queries using the stylesheet located at
-http://www.w3.org/2014/10/XQueryX/xqueryx.xsl. 
+http://www.w3.org/2017/03/XQueryX/xqueryx.xsl. 
 
 
 
 XQueryX 3.1
-(1 October 2014 version)
+(21 March 2017 version)
 
 
 This document describes the names that are defined in this namespace at the time of publication. 
@@ -44,10 +44,10 @@ corresponding to XQuery 3.1 extensions.
 
 
 XQuery 3.1 Requirements
-(1 October 2014 version)
+(13 December 2016 version)
 
 XQuery 3.1
-(1 October 2014 version)
+(21 March 2017 version)
 
 Resource Directory Description Language (RDDL) (4 July 2007)
 

--- a/specifications/xqueryx-31/html/ns-xqueryx.xhtml
+++ b/specifications/xqueryx-31/html/ns-xqueryx.xhtml
@@ -32,7 +32,7 @@
                This document describes the namespace
                <code>http://www.w3.org/2005/XQueryX</code> defined by the
                <a href="#xqueryx-31-ref">[XQueryX 3.1]</a> specification
-               (October 2014 version). 
+               (March 2017 version). 
                This namespace is typically identified by the namespace prefix <code>xqx:</code>,
                which is <em>not</em> a predefined prefix. 
                For updated information, please refer to the latest version of the
@@ -71,13 +71,13 @@
                is defined by an XML Schema. 
                
             </p>
-            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XML Schema for validation" xlink:role="http://www.w3.org/2001/XMLSchema" xlink:arcrole="http://www.rddl.org/purposes#schema-validation" xlink:href="http://www.w3.org/2014/10/XQueryX/xqueryx.xsd" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XML Schema for validation" xlink:role="http://www.w3.org/2001/XMLSchema" xlink:arcrole="http://www.rddl.org/purposes#schema-validation" xlink:href="http://www.w3.org/2017/03/XQueryX/xqueryx.xsd" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                
                <p>
                   This schema specifies the XML syntax of the XQuery expressions defined in
                   <a href="#xquery-31-ref">[XQuery 3.1]</a>. 
                   It is located at
-                  <a href="http://www.w3.org/2014/10/XQueryX/xqueryx.xsd">http://www.w3.org/2014/10/XQueryX/xqueryx.xsd</a>.
+                  <a href="http://www.w3.org/2017/03/XQueryX/xqueryx.xsd">http://www.w3.org/2017/03/XQueryX/xqueryx.xsd</a>.
                   
                </p>
                
@@ -96,13 +96,13 @@
             
             <h2><a name="stylesheet" id="stylesheet"></a>3 XSLT Stylesheet
             </h2>
-            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XSLT stylesheet for transformation into human-readable syntax" xlink:role="http://www.isi.edu/in-notes/iana/assignments/media-types/application/xslt+xml" xlink:arcrole="http://www.w3.org/1999/XSL/Transform" xlink:href="http://www.w3.org/2014/10/XQueryX/xqueryx.xsl" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XSLT stylesheet for transformation into human-readable syntax" xlink:role="http://www.isi.edu/in-notes/iana/assignments/media-types/application/xslt+xml" xlink:arcrole="http://www.w3.org/1999/XSL/Transform" xlink:href="http://www.w3.org/2017/03/XQueryX/xqueryx.xsl" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                
                <p>
                   Queries written using the XML syntax of <a href="#xquery-31-ref">[XQuery 3.1]</a> have semantics
                   that are defined by the XQuery "human-readable" syntax that results from transforming
                   those XML syntax queries using the stylesheet located at
-                  <a href="http://www.w3.org/2014/10/XQueryX/xqueryx.xsl">http://www.w3.org/2014/10/XQueryX/xqueryx.xsl</a>. 
+                  <a href="http://www.w3.org/2017/03/XQueryX/xqueryx.xsl">http://www.w3.org/2017/03/XQueryX/xqueryx.xsl</a>. 
                   
                </p>
                
@@ -117,11 +117,11 @@
                <dd>
                   <div class="resource">
                      
-                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQueryX 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="http://www.w3.org/TR/2014/WD-xqueryx-31-2014101/" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQueryX 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="http://www.w3.org/TR/2017/WD-xqueryx-31-20170321/" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                         
                         <p>
-                           <a href="http://www.w3.org/TR/2014/WD-xqueryx-31-2014101/">XQueryX 3.1</a>
-                           (1 October 2014 version)
+                           <a href="https://www.w3.org/TR/2017/REC-xqueryx-31-20170321/">XQueryX 3.1</a>
+                           (21 March 2017 version)
                            
                         </p>
                         
@@ -152,10 +152,10 @@
                <dd>
                   <div class="resource">
                      
-                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1 Requirements and Use Cases" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/xquery-31-requirements" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1 Requirements and Use Cases" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="https://www.w3.org/TR/xquery-31-requirements" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                         
-                        <p><a href="http://www.w3.org/TR/2014/WD-xquery-31-requirements-2014101/">XQuery 3.1 Requirements</a>
-                           (1 October 2014 version)
+                        <p><a href="https://www.w3.org/TR/2016/NOTE-xquery-31-requirements-20161213/">XQuery 3.1 Requirements</a>
+                           (13 December 2016 version)
                         </p>
                         
                      </rddl:resource>
@@ -166,10 +166,10 @@
                <dd>
                   <div class="resource">
                      
-                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="https://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                         
-                        <p><a href="http://www.w3.org/TR/2014/WD-xquery-31-2014101/">XQuery 3.1</a>
-                           (1 October 2014 version)
+                        <p><a href="https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a>
+                           (21 March 2017 version)
                         </p>
                         
                      </rddl:resource>

--- a/specifications/xqueryx-31/src/ns-xqueryx.xml
+++ b/specifications/xqueryx-31/src/ns-xqueryx.xml
@@ -1,51 +1,51 @@
 <?xml version="1.0"?>
 <!DOCTYPE spec SYSTEM "../../../schema/qtnamespaces.dtd" [
-<!ENTITY doc.date.day "1">
-<!ENTITY doc.date.month "October">
-<!ENTITY doc.date.MM "10">
-<!ENTITY doc.date.year "2014">
+<!ENTITY doc.date.day "21">
+<!ENTITY doc.date.month "March">
+<!ENTITY doc.date.MM "03">
+<!ENTITY doc.date.year "2017">
 <!ENTITY doc.nsname "XQueryX">
 <!ENTITY doc.publoc "http://www.w3.org/2005/&doc.nsname;">
 <!ENTITY nsname     "http://www.w3.org/2005/&doc.nsname;">
 
-<!ENTITY xqx.spec.date.day "1">
-<!ENTITY xqx.spec.date.month "October">
-<!ENTITY xqx.spec.date.MM "10">
-<!ENTITY xqx.spec.date.year "2014">
+<!ENTITY xqx.spec.date.day "21">
+<!ENTITY xqx.spec.date.month "March">
+<!ENTITY xqx.spec.date.MM "03">
+<!ENTITY xqx.spec.date.year "2017">
 <!ENTITY xqx.spec.ver "31">
-<!ENTITY xqx.spec.doctype "WD">
+<!ENTITY xqx.spec.doctype "REC">
 <!ENTITY xqx.spec.name "xqueryx">
-<!ENTITY xqx.loc     "http://www.w3.org/TR/&xqx.spec.name;-&xqx.spec.ver;">
-<!ENTITY xqx.loc.dated     "http://www.w3.org/TR/&xqx.spec.date.year;/&xqx.spec.doctype;-&xqx.spec.name;-&xqx.spec.ver;-&xqx.spec.date.year;&xqx.spec.date.MM;&xqx.spec.date.day;/">
+<!ENTITY xqx.loc     "https://www.w3.org/TR/&xqx.spec.name;-&xqx.spec.ver;">
+<!ENTITY xqx.loc.dated     "https://www.w3.org/TR/&xqx.spec.date.year;/&xqx.spec.doctype;-&xqx.spec.name;-&xqx.spec.ver;-&xqx.spec.date.year;&xqx.spec.date.MM;&xqx.spec.date.day;/">
 
-<!ENTITY xq.spec.date.day "1">
-<!ENTITY xq.spec.date.month "October">
-<!ENTITY xq.spec.date.MM "10">
-<!ENTITY xq.spec.date.year "2014">
+<!ENTITY xq.spec.date.day "21">
+<!ENTITY xq.spec.date.month "March">
+<!ENTITY xq.spec.date.MM "03">
+<!ENTITY xq.spec.date.year "2017">
 <!ENTITY xq.spec.ver "31">
-<!ENTITY xq.spec.doctype "WD">
+<!ENTITY xq.spec.doctype "REC">
 <!ENTITY xq.spec.name "xquery">
-<!ENTITY xq.loc     "http://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
-<!ENTITY xq.loc.dated     "http://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
+<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
+<!ENTITY xq.loc.dated     "https://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
 
-<!ENTITY xqreq.spec.date.day "1">
-<!ENTITY xqreq.spec.date.month "October">
-<!ENTITY xqreq.spec.date.MM "10">
-<!ENTITY xqreq.spec.date.year "2014">
+<!ENTITY xqreq.spec.date.day "13">
+<!ENTITY xqreq.spec.date.month "December">
+<!ENTITY xqreq.spec.date.MM "12">
+<!ENTITY xqreq.spec.date.year "2016">
 <!ENTITY xqreq.spec.ver "31">
-<!ENTITY xqreq.spec.doctype "WD">
+<!ENTITY xqreq.spec.doctype "NOTE">
 <!ENTITY xqreq.spec.name "xquery-&xqreq.spec.ver;-requirements">
-<!ENTITY xqreq.loc     "http://www.w3.org/TR/&xqreq.spec.name;">
-<!ENTITY xqreq.loc.dated     "http://www.w3.org/TR/&xqreq.spec.date.year;/&xqreq.spec.doctype;-&xqreq.spec.name;-&xqreq.spec.date.year;&xqreq.spec.date.MM;&xqreq.spec.date.day;/">
+<!ENTITY xqreq.loc     "https://www.w3.org/TR/&xqreq.spec.name;">
+<!ENTITY xqreq.loc.dated     "https://www.w3.org/TR/&xqreq.spec.date.year;/&xqreq.spec.doctype;-&xqreq.spec.name;-&xqreq.spec.date.year;&xqreq.spec.date.MM;&xqreq.spec.date.day;/">
 ]>
-<spec w3c-doctype="wd" status="ext-review"
+<spec w3c-doctype="rec" status="ext-review"
       xmlns:rddl="http://www.rddl.org/"
       xmlns:xlink="http://www.w3.org/1999/xlink">
   <header>
     <title>XQueryX 3.1 Namespace Document</title>
     <version></version>
     <w3c-designation></w3c-designation>
-    <w3c-doctype>W3C Working Draft</w3c-doctype>
+    <w3c-doctype>W3C Recommendation</w3c-doctype>
     <pubdate>
       <day>&doc.date.day;</day>
       <month>&doc.date.month;</month>

--- a/specifications/xslt-xquery-serialization-31/html/ns-xslt-xquery-serialization.html
+++ b/specifications/xslt-xquery-serialization-31/html/ns-xslt-xquery-serialization.html
@@ -34,7 +34,7 @@
 <p>This document describes the namespace
 <code>http://www.w3.org/2010/xslt-xquery-serialization</code>
 defined by the <a href="#xslt-xquery-serialization-31-ref">[XQuery
-and XQuery Serialization 3.1]</a> specification (December 2015
+and XQuery Serialization 3.1]</a> specification (March 2017
 version). This namespace is typically identified by the namespace
 prefix <code>output:</code>, which is <em>not</em> a predefined
 prefix. For updated information, please refer to the latest version
@@ -68,8 +68,8 @@ parameters.</p>
 <p>This schema defines the XML syntax of serialization parameters
 specified in <a href="#xslt-xquery-serialization-31-ref">[XQuery
 and XQuery Serialization 3.1]</a>. It is located at <a href=
-"http://www.w3.org/2015/12/xslt-xquery-serialization/schema-for-serialization-parameters.xsd">
-http://www.w3.org/2015/12/xslt-xquery-serialization/schema-for-serialization-parameters.xsd</a>.</p>
+"http://www.w3.org/2017/03/xslt-xquery-serialization/schema-for-serialization-parameters.xsd">
+http://www.w3.org/2017/03/xslt-xquery-serialization/schema-for-serialization-parameters.xsd</a>.</p>
 <p>The following serialization parameters are defined by that
 schema:</p>
 <blockquote>
@@ -150,9 +150,8 @@ Serialization 3.1</span></dt>
 <dd>
 <div class="resource">
 <p><a href=
-"http://www.w3.org/TR/2015/CR-xslt-xquery-serialization-31-20151217/">
-XSLT and XQuery Serialization 3.1</a> (17 December 2015
-version)</p>
+"https://www.w3.org/TR/2017/REC-xslt-xquery-serialization-31-20170321/">
+XSLT and XQuery Serialization 3.1</a> (21 March 2017 version)</p>
 <p>This document describes the names that are defined in this
 namespace at the time of publication. The W3C reserves the right to
 define additional names in this namespace in the future. <a href=
@@ -174,8 +173,8 @@ Cases</span></dt>
 <dd>
 <div class="resource">
 <p><a href=
-"http://www.w3.org/TR/2015/NOTE-xquery-31-requirements-20150811/">XQuery
-3.1 Requirements</a> (11 August 2015 version)</p>
+"https://www.w3.org/TR/2016/NOTE-xquery-31-requirements-20161213/">XQuery
+3.1 Requirements</a> (13 December 2016 version)</p>
 </div>
 </dd>
 <dt class="label"><span><a name="xquery-31-ref" id=
@@ -183,8 +182,8 @@ Cases</span></dt>
 <dd>
 <div class="resource">
 <p><a href=
-"http://www.w3.org/TR/2015/CR-xquery-31-20151217/">XQuery 3.1</a>
-(17 December 2015 version)</p>
+"https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a>
+(21 March 2017 version)</p>
 </div>
 </dd>
 <dt class="label"><span><a name="rddl-ref" id=

--- a/specifications/xslt-xquery-serialization-31/html/ns-xslt-xquery-serialization.rdf
+++ b/specifications/xslt-xquery-serialization-31/html/ns-xslt-xquery-serialization.rdf
@@ -20,11 +20,11 @@
 This schema defines the XML syntax of serialization parameters
 specified in [XQuery and XQuery Serialization 3.1].
 It is located at
-http://www.w3.org/2015/12/xslt-xquery-serialization/schema-for-serialization-parameters.xsd.
+http://www.w3.org/2017/03/xslt-xquery-serialization/schema-for-serialization-parameters.xsd.
 
 output:allow-duplicate-namesoutput:byte-order-markoutput:cdata-section-elementsoutput:doctype-publicoutput:doctype-systemoutput:encodingoutput:escape-uri-attributesoutput:html-versionoutput:include-content-typeoutput:indentoutput:item-separatoroutput:json-node-output-methodoutput:media-typeoutput:methodoutput:normalization-formoutput:omit-xml-declarationoutput:standaloneoutput:suppress-indentationoutput:undeclare-prefixesoutput:use-character-mapsoutput:version
 XSLT and XQuery Serialization 3.1
-(17 December 2015 version)
+(21 March 2017 version)
 
 This document describes the names that are defined in this namespace at the time of publication. 
 The W3C reserves the right to define additional names in this namespace in the future. 
@@ -34,10 +34,10 @@ It may, however, be augmented by other specifications that define Serialization 
 
 
 XQuery 3.1 Requirements
-(11 August 2015 version)
+(13 December 2016 version)
 
 XQuery 3.1
-(17 December 2015 version)
+(21 March 2017 version)
 
 Resource Directory Description Language (RDDL) (4 July 2007)
 

--- a/specifications/xslt-xquery-serialization-31/html/ns-xslt-xquery-serialization.xhtml
+++ b/specifications/xslt-xquery-serialization-31/html/ns-xslt-xquery-serialization.xhtml
@@ -31,7 +31,7 @@
                This document describes the namespace
                <code>http://www.w3.org/2010/xslt-xquery-serialization</code> defined by the
                <a href="#xslt-xquery-serialization-31-ref">[XQuery and XQuery Serialization 3.1]</a> specification
-               (December 2015 version). 
+               (March 2017 version). 
                This namespace is typically identified by the namespace prefix <code>output:</code>,
                which is <em>not</em> a predefined prefix. 
                For updated information, please refer to the latest version of the
@@ -71,13 +71,13 @@
                implementation-defined modifiers to serialization parameters.
                
             </p>
-            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XML Schema for validation" xlink:role="http://www.w3.org/2001/XMLSchema" xlink:arcrole="http://www.rddl.org/purposes#schema-validation" xlink:href="http://www.w3.org/2015/12/xslt-xquery-serialization/schema-for-serialization-parameters.xsd" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+            <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XML Schema for validation" xlink:role="http://www.w3.org/2001/XMLSchema" xlink:arcrole="http://www.rddl.org/purposes#schema-validation" xlink:href="http://www.w3.org/2017/03/xslt-xquery-serialization/schema-for-serialization-parameters.xsd" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                
                <p>
                   This schema defines the XML syntax of serialization parameters
                   specified in <a href="#xslt-xquery-serialization-31-ref">[XQuery and XQuery Serialization 3.1]</a>.
                   It is located at
-                  <a href="http://www.w3.org/2015/12/xslt-xquery-serialization/schema-for-serialization-parameters.xsd">http://www.w3.org/2015/12/xslt-xquery-serialization/schema-for-serialization-parameters.xsd</a>.
+                  <a href="http://www.w3.org/2017/03/xslt-xquery-serialization/schema-for-serialization-parameters.xsd">http://www.w3.org/2017/03/xslt-xquery-serialization/schema-for-serialization-parameters.xsd</a>.
                   
                </p>
                
@@ -164,10 +164,10 @@
                <dd>
                   <div class="resource">
                      
-                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery and XQuery Serialization 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="http://www.w3.org/TR/xslt-xquery-serialization-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery and XQuery Serialization 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#normative-reference" xlink:href="https://www.w3.org/TR/xslt-xquery-serialization-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                         
-                        <p><a href="http://www.w3.org/TR/2015/CR-xslt-xquery-serialization-31-20151217/">XSLT and XQuery Serialization 3.1</a>
-                           (17 December 2015 version)
+                        <p><a href="https://www.w3.org/TR/2017/REC-xslt-xquery-serialization-31-20170321/">XSLT and XQuery Serialization 3.1</a>
+                           (21 March 2017 version)
                         </p>
                         
                         
@@ -197,10 +197,10 @@
                <dd>
                   <div class="resource">
                      
-                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1 Requirements and Use Cases" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/xquery-31-requirements" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1 Requirements and Use Cases" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="https://www.w3.org/TR/xquery-31-requirements" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                         
-                        <p><a href="http://www.w3.org/TR/2015/NOTE-xquery-31-requirements-20150811/">XQuery 3.1 Requirements</a>
-                           (11 August 2015 version)
+                        <p><a href="https://www.w3.org/TR/2016/NOTE-xquery-31-requirements-20161213/">XQuery 3.1 Requirements</a>
+                           (13 December 2016 version)
                         </p>
                         
                      </rddl:resource>
@@ -211,10 +211,10 @@
                <dd>
                   <div class="resource">
                      
-                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="http://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
+                     <rddl:resource xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rddl="http://www.rddl.org/" xlink:title="XQuery 3.1" xlink:role="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional" xlink:arcrole="http://www.rddl.org/purposes#non-normative-reference" xlink:href="https://www.w3.org/TR/xquery-" xlink:type="simple" xlink:embed="none" xlink:actuate="none">
                         
-                        <p><a href="http://www.w3.org/TR/2015/CR-xquery-31-20151217/">XQuery 3.1</a>
-                           (17 December 2015 version)
+                        <p><a href="https://www.w3.org/TR/2017/REC-xquery-31-20170321/">XQuery 3.1</a>
+                           (21 March 2017 version)
                         </p>
                         
                      </rddl:resource>

--- a/specifications/xslt-xquery-serialization-31/src/ns-xslt-xquery-serialization.xml
+++ b/specifications/xslt-xquery-serialization-31/src/ns-xslt-xquery-serialization.xml
@@ -1,51 +1,51 @@
 <?xml version="1.0"?>
 <!DOCTYPE spec SYSTEM "../../../schema/qtnamespaces.dtd" [
-<!ENTITY doc.date.day "01">
-<!ENTITY doc.date.month "December">
-<!ENTITY doc.date.MM "12">
-<!ENTITY doc.date.year "2015">
+<!ENTITY doc.date.day "21">
+<!ENTITY doc.date.month "March">
+<!ENTITY doc.date.MM "03">
+<!ENTITY doc.date.year "2017">
 <!ENTITY doc.nsname "xslt-xquery-serialization">
 <!ENTITY doc.publoc "http://www.w3.org/2010/&doc.nsname;">
 <!ENTITY nsname     "http://www.w3.org/2010/&doc.nsname;">
 
-<!ENTITY ser.spec.date.day "17">
-<!ENTITY ser.spec.date.month "December">
-<!ENTITY ser.spec.date.MM "12">
-<!ENTITY ser.spec.date.year "2015">
+<!ENTITY ser.spec.date.day "21">
+<!ENTITY ser.spec.date.month "March">
+<!ENTITY ser.spec.date.MM "03">
+<!ENTITY ser.spec.date.year "2017">
 <!ENTITY ser.spec.ver "31">
-<!ENTITY ser.spec.doctype "CR">
+<!ENTITY ser.spec.doctype "REC">
 <!ENTITY ser.spec.name "xslt-xquery-serialization">
-<!ENTITY ser.loc     "http://www.w3.org/TR/&ser.spec.name;-&spec.ver;">
-<!ENTITY ser.loc.dated     "http://www.w3.org/TR/&ser.spec.date.year;/&ser.spec.doctype;-&ser.spec.name;-&ser.spec.ver;-&ser.spec.date.year;&ser.spec.date.MM;&ser.spec.date.day;/">
+<!ENTITY ser.loc     "https://www.w3.org/TR/&ser.spec.name;-&spec.ver;">
+<!ENTITY ser.loc.dated     "https://www.w3.org/TR/&ser.spec.date.year;/&ser.spec.doctype;-&ser.spec.name;-&ser.spec.ver;-&ser.spec.date.year;&ser.spec.date.MM;&ser.spec.date.day;/">
 
-<!ENTITY xq.spec.date.day "17">
-<!ENTITY xq.spec.date.month "December">
-<!ENTITY xq.spec.date.MM "12">
-<!ENTITY xq.spec.date.year "2015">
+<!ENTITY xq.spec.date.day "21">
+<!ENTITY xq.spec.date.month "March">
+<!ENTITY xq.spec.date.MM "03">
+<!ENTITY xq.spec.date.year "2017">
 <!ENTITY xq.spec.ver "31">
-<!ENTITY xq.spec.doctype "CR">
+<!ENTITY xq.spec.doctype "REC">
 <!ENTITY xq.spec.name "xquery">
-<!ENTITY xq.loc     "http://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
-<!ENTITY xq.loc.dated     "http://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
+<!ENTITY xq.loc     "https://www.w3.org/TR/&xq.spec.name;-&spec.ver;">
+<!ENTITY xq.loc.dated     "https://www.w3.org/TR/&xq.spec.date.year;/&xq.spec.doctype;-&xq.spec.name;-&xq.spec.ver;-&xq.spec.date.year;&xq.spec.date.MM;&xq.spec.date.day;/">
 
-<!ENTITY xqreq.spec.date.day "11">
-<!ENTITY xqreq.spec.date.month "August">
-<!ENTITY xqreq.spec.date.MM "08">
-<!ENTITY xqreq.spec.date.year "2015">
+<!ENTITY xqreq.spec.date.day "13">
+<!ENTITY xqreq.spec.date.month "December">
+<!ENTITY xqreq.spec.date.MM "12">
+<!ENTITY xqreq.spec.date.year "2016">
 <!ENTITY xqreq.spec.ver "31">
 <!ENTITY xqreq.spec.doctype "NOTE">
 <!ENTITY xqreq.spec.name "xquery-&xqreq.spec.ver;-requirements">
-<!ENTITY xqreq.loc     "http://www.w3.org/TR/&xqreq.spec.name;">
-<!ENTITY xqreq.loc.dated     "http://www.w3.org/TR/&xqreq.spec.date.year;/&xqreq.spec.doctype;-&xqreq.spec.name;-&xqreq.spec.date.year;&xqreq.spec.date.MM;&xqreq.spec.date.day;/">
+<!ENTITY xqreq.loc     "https://www.w3.org/TR/&xqreq.spec.name;">
+<!ENTITY xqreq.loc.dated     "https://www.w3.org/TR/&xqreq.spec.date.year;/&xqreq.spec.doctype;-&xqreq.spec.name;-&xqreq.spec.date.year;&xqreq.spec.date.MM;&xqreq.spec.date.day;/">
 ]>
-<spec w3c-doctype="cr" status="ext-review"
+<spec w3c-doctype="rec" status="ext-review"
       xmlns:rddl="http://www.rddl.org/"
       xmlns:xlink="http://www.w3.org/1999/xlink">
   <header>
     <title>XSLT and XQuery Serialization 3.1 Namespace Document</title>
     <version></version>
     <w3c-designation></w3c-designation>
-    <w3c-doctype>W3C Candidate Recommendation</w3c-doctype>
+    <w3c-doctype>W3C Recommendation</w3c-doctype>
     <pubdate>
       <day>&doc.date.day;</day>
       <month>&doc.date.month;</month>


### PR DESCRIPTION
This PR fixes [Bug 30189 - [ser31] Namespace document for serialization is out of date](https://www.w3.org/Bugs/Public/show_bug.cgi?id=30189) and also addresses similar out of date hrefs in the following namespace documents:

- ns-local.html
- ns-xquery.html
- ns-xqueryx.html
- ns-xslt-xquery-serialization.html
